### PR TITLE
Update Sorter.cs

### DIFF
--- a/src/WARP.XrmSolutionAssistant/WARP.XrmSolutionAssistant.Core/Workers/Sorter.cs
+++ b/src/WARP.XrmSolutionAssistant/WARP.XrmSolutionAssistant.Core/Workers/Sorter.cs
@@ -35,6 +35,7 @@ namespace WARP.XrmSolutionAssistant.Core.Workers
             SortContainerByAttributeValue(doc, "Descriptions", "LCID"); // Sitemap
             SortContainerByAttributeValue(doc, "Titles", "LCID"); // Sitemap
             SortContainerByAttributeValue(doc, "CustomLabels", "languagecode"); // Relationships
+            SortContainerByAttributeValue(doc, "AppModuleRoleMaps", "id"); // AppModule.xml
 
             SortMissingDependencies(doc);
 


### PR DESCRIPTION
The Solution Packager doesn't consistently order AppModuleRoleMaps entries in the `AppModule.xml` file: `Solution/AppModules/<entity>/AppModule.xml`. 

This PR addresses the issue by ordering them based by ID.